### PR TITLE
[ft][643] Components Library: Steps component for section with custom style

### DIFF
--- a/src/components/WizardSteps/WizardSteps.styles.ts
+++ b/src/components/WizardSteps/WizardSteps.styles.ts
@@ -1,0 +1,212 @@
+export const getWizardStepsStyles = (containerId: string, arrowWidth: number): string => `
+	#${containerId} {
+		--wizard-arrow-width: ${arrowWidth}px;
+		--wizard-height: 48px;
+		--wizard-padding: 8px;
+		--wizard-border-width: 2px;
+		--wizard-color-wait: #F4F8FB;
+		--wizard-color-active: #d9dfe3;
+		--wizard-color-error: #F5423E;
+		--itsa-primary: #EA3B48;
+		--wizard-text-wait: #78909C;
+		--wizard-text-active: #263238;
+		--wizard-text-error: #FFFFFF;
+	}
+
+	#${containerId} .wizard-steps.ant-steps {
+		display: flex;
+		align-items: stretch;
+		padding: 0;
+		background: transparent;
+	}
+
+	#${containerId} .wizard-steps .ant-steps-item {
+		flex: 1;
+		overflow: visible;
+		margin: 0 !important;
+		padding: 0 !important;
+		position: relative;
+	}
+
+	#${containerId} .wizard-steps .ant-steps-item-tail,
+	#${containerId} .wizard-steps .ant-steps-item-icon {
+		display: none !important;
+	}
+
+	#${containerId} .wizard-steps .ant-steps-item-container {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		cursor: pointer;
+		height: var(--wizard-height);
+		padding: var(--wizard-padding);
+		border-top: var(--wizard-border-width) solid transparent;
+		border-bottom: var(--wizard-border-width) solid transparent;
+		background: var(--wizard-color-wait);
+		position: relative;
+		transition: background-color 0.3s ease, border-color 0.3s ease;
+		overflow: visible;
+	}
+
+	#${containerId} .wizard-steps .ant-steps-item:first-child .ant-steps-item-container {
+		border-left: var(--wizard-border-width) solid transparent;
+		border-top-left-radius: 6px;
+		border-bottom-left-radius: 6px;
+		padding-left: calc(var(--wizard-padding) * 1.5);
+	}
+
+	#${containerId} .wizard-steps .ant-steps-item:last-child .ant-steps-item-container {
+		border-right: var(--wizard-border-width) solid transparent;
+		border-top-right-radius: 6px;
+		border-bottom-right-radius: 6px;
+		padding-right: calc(var(--wizard-padding) * 1.5);
+	}
+
+	#${containerId} .wizard-steps .ant-steps-item:not(:first-child):not(:last-child) .ant-steps-item-container {
+		clip-path: polygon(
+			0 0,
+			calc(95% - var(--wizard-arrow-width)) 0,
+			95% 50%,
+			calc(95% - var(--wizard-arrow-width)) 100%,
+			0 100%,
+			var(--wizard-arrow-width) 50%
+		) !important;
+		margin-left: calc(var(--wizard-arrow-width) * -0.6);
+		margin-right: calc(var(--wizard-arrow-width) * -0.6);
+		padding-left: calc(var(--wizard-padding) + var(--wizard-arrow-width) * 1.4);
+		padding-right: calc(var(--wizard-padding) + var(--wizard-arrow-width) * 1.4);
+	}
+
+	#${containerId} .wizard-steps .ant-steps-item:first-child:not(:last-child) .ant-steps-item-container {
+		clip-path: polygon(
+			0 0,
+			calc(95% - var(--wizard-arrow-width)) 0,
+			95% 50%,
+			calc(95% - var(--wizard-arrow-width)) 100%,
+			0 100%
+		) !important;
+		margin-right: calc(var(--wizard-arrow-width) * -0.6);
+		padding-right: calc(var(--wizard-padding) + var(--wizard-arrow-width) * 1.4);
+		border-top-left-radius: 6px;
+		border-bottom-left-radius: 6px;
+	}
+
+	#${containerId} .wizard-steps .ant-steps-item:last-child:not(:first-child) .ant-steps-item-container {
+		clip-path: polygon(
+			0 0,
+			100% 0,
+			100% 100%,
+			0 100%,
+			var(--wizard-arrow-width) 50%
+		) !important;
+		margin-left: calc(var(--wizard-arrow-width) * -0.6);
+		padding-left: calc(var(--wizard-padding) + var(--wizard-arrow-width) * 1.4);
+		border-top-right-radius: 6px;
+		border-bottom-right-radius: 6px;
+	}
+
+	#${containerId} .wizard-steps .ant-steps-item-content,
+	#${containerId} .wizard-steps .ant-steps-item-title {
+		font-weight: 600;
+		font-size: 0.875rem;
+		line-height: 1.25rem;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		color: var(--wizard-text-wait) !important;
+		margin: 0 !important;
+		padding: 0 !important;
+		z-index: 2;
+	}
+
+	#${containerId} .wizard-steps .ant-steps-item-description {
+		display: none !important;
+	}
+
+	#${containerId} .wizard-steps .ant-steps-item-wait .ant-steps-item-container {
+		background-color: var(--wizard-color-wait);
+		border-color: var(--wizard-color-wait);
+	}
+
+	#${containerId} .wizard-steps .ant-steps-item-wait .ant-steps-item-title {
+		color: var(--wizard-text-wait) !important;
+	}
+
+	#${containerId} .wizard-steps .ant-steps-item-process .ant-steps-item-container,
+	#${containerId} .wizard-steps .ant-steps-item-finish .ant-steps-item-container {
+		background-color: var(--wizard-color-active);
+		border-color: var(--wizard-color-active);
+	}
+
+	#${containerId} .wizard-steps .ant-steps-item-process .ant-steps-item-title,
+	#${containerId} .wizard-steps .ant-steps-item-finish .ant-steps-item-title {
+		color: var(--wizard-text-active) !important;
+	}
+
+	#${containerId} .wizard-steps .ant-steps-item-process .ant-steps-item-container {
+		z-index: 3;
+	}
+
+	#${containerId} .wizard-steps .ant-steps-item-error .ant-steps-item-container {
+		background-color: var(--wizard-color-error);
+		border-color: var(--wizard-color-error);
+	}
+
+	#${containerId} .wizard-steps .ant-steps-item-error .ant-steps-item-title {
+		color: var(--wizard-text-error) !important;
+	}
+
+	#${containerId} .wizard-steps .ant-steps-item:not(.ant-steps-item-disabled):hover .ant-steps-item-title {
+		color: var(--itsa-primary) !important;
+		transition: color 0.2s ease;
+	}
+
+	#${containerId} .wizard-steps .ant-steps-item-disabled .ant-steps-item-container {
+		cursor: not-allowed;
+		opacity: 0.6;
+	}
+
+	@media (max-width: 640px) {
+		#${containerId} {
+			--wizard-padding: 12px;
+		}
+
+		#${containerId} .wizard-steps.ant-steps {
+			flex-direction: column;
+			gap: 8px;
+		}
+
+		#${containerId} .wizard-steps .ant-steps-item {
+			width: 100%;
+		}
+
+		#${containerId} .wizard-steps .ant-steps-item-container {
+			height: auto;
+			min-height: 48px;
+			border-radius: 6px !important;
+		}
+
+		#${containerId} .wizard-steps .ant-steps-item:not(:first-child):not(:last-child) .ant-steps-item-container,
+		#${containerId} .wizard-steps .ant-steps-item:first-child:not(:last-child) .ant-steps-item-container,
+		#${containerId} .wizard-steps .ant-steps-item:last-child:not(:first-child) .ant-steps-item-container {
+			clip-path: none !important;
+			margin: 0 !important;
+			padding: var(--wizard-padding) !important;
+			border-radius: 6px !important;
+		}
+
+		#${containerId} .wizard-steps .ant-steps-item:first-child .ant-steps-item-container {
+			padding: var(--wizard-padding) !important;
+		}
+
+		#${containerId} .wizard-steps .ant-steps-item:last-child .ant-steps-item-container {
+			padding: var(--wizard-padding) !important;
+		}
+
+		#${containerId} .wizard-steps .ant-steps-item-title {
+			font-size: 0.875rem;
+			white-space: normal;
+			text-align: center;
+		}
+	}
+`;

--- a/src/components/WizardSteps/WizardSteps.tsx
+++ b/src/components/WizardSteps/WizardSteps.tsx
@@ -1,0 +1,53 @@
+import { Steps, type StepsProps } from 'antd';
+import { getWizardStepsStyles } from './WizardSteps.styles';
+
+export interface IWizardStepsProps {
+	current: number;
+	items: StepsProps['items'];
+	onChange?: (stepIndex: number) => void;
+	className?: string;
+	type?: 'default' | 'navigation' | 'inline' | 'itsa-panel';
+	height?: number;
+	arrowWidth?: number;
+	withContainer?: boolean;
+}
+
+export const WizardSteps = ({ 
+	current, 
+	items, 
+	onChange, 
+	className = '', 
+	type = 'default',
+	height = 48, 
+	arrowWidth = 24,
+	withContainer = true
+}: IWizardStepsProps) => {
+	const containerId = `wizard-steps-${Math.random().toString(36).substr(2, 9)}`;
+	const isItsaPanel = type === 'itsa-panel';
+
+	const containerStyles = {
+		'--wizard-height': `${height}px`,
+		'--wizard-arrow-width': `${arrowWidth}px`,
+	} as React.CSSProperties;
+
+	if (!isItsaPanel) {
+		return (
+			<div className={className}>
+				<Steps type={type} current={current} items={items} onChange={onChange} />
+			</div>
+		);
+	}
+
+	return (
+		<>
+			<style>{getWizardStepsStyles(containerId, arrowWidth)}</style>
+			<div 
+				id={containerId} 
+				className={withContainer ? `bg-white p-2 rounded-lg shadow-sm ${className}` : className}
+				style={containerStyles}
+			>
+				<Steps className="wizard-steps" current={current} items={items} onChange={onChange} />
+			</div>
+		</>
+	);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,8 @@ export { Tooltip } from './components/Tooltip/Tooltip';
 export { TreeNode } from './components/TreeNode';
 export { UserProfileDrawer } from './components/UserProfileDrawer';
 export { WithoutInformation } from './components/WithoutInformation';
+export { WizardSteps } from './components/WizardSteps/WizardSteps';
+export type { IWizardStepsProps } from './components/WizardSteps/WizardSteps';
 export { ErrorsProvider } from './routing/components/ErrorsProvider';
 export { LayoutComponent } from './routing/components/LayoutComponent';
 export { Iconos } from './components/IconSelector';

--- a/src/storybook/components/WizardSteps.stories.tsx
+++ b/src/storybook/components/WizardSteps.stories.tsx
@@ -1,0 +1,262 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import type { StepsProps } from 'antd';
+import { WizardSteps } from '../../components/WizardSteps/WizardSteps';
+
+const meta = {
+	title: 'Components/WizardSteps',
+	component: WizardSteps,
+	parameters: {
+		layout: 'padded',
+		docs: {
+			description: {
+				component:
+					'Control de navegación secuencial con soporte multiestilo. Permite alternar entre ' +
+					'un diseño de indicadores en flecha (estilo "itsa-panel") y las variantes ' +
+					'estándar de Ant Design (default, navigation e inline), facilitando la ' +
+					'adaptación al flujo de usuario.',
+			},
+		},
+	},
+	tags: ['autodocs'],
+	argTypes: {
+		current: {
+			control: { type: 'number', min: 0, max: 3 },
+			description: 'Índice del paso actual (base 0)',
+			table: {
+				type: { summary: 'number' },
+				defaultValue: { summary: '0' },
+			},
+		},
+		type: {
+			control: { type: 'select' },
+			options: ['default', 'navigation', 'inline', 'itsa-panel'],
+			description:
+				'Tipo de visualización del componente. "itsa-panel" aplica estilo chevron personalizado, otros tipos usan estilos de Ant Design',
+			table: {
+				type: { summary: 'string' },
+				defaultValue: { summary: 'default' },
+			},
+		},
+		height: {
+			control: { type: 'number', min: 32, max: 80 },
+			description: 'Altura del componente en píxeles. Solo aplicable para tipo "itsa-panel"',
+			table: {
+				type: { summary: 'number' },
+				defaultValue: { summary: '48' },
+			},
+		},
+		arrowWidth: {
+			control: { type: 'number', min: 16, max: 40 },
+			description: 'Ancho de la flecha/chevron en píxeles. Solo aplicable para tipo "itsa-panel"',
+			table: {
+				type: { summary: 'number' },
+				defaultValue: { summary: '24' },
+			},
+		},
+		items: {
+			description: 'Array de elementos de paso con título y estado',
+			table: {
+				type: { summary: 'StepsProps["items"]' },
+			},
+		},
+		onChange: {
+			description: 'Callback ejecutado cuando el usuario hace clic en un paso',
+			table: {
+				type: { summary: '(stepIndex: number) => void' },
+			},
+		},
+		className: {
+			description: 'Clase CSS adicional para personalización',
+			table: {
+				type: { summary: 'string' },
+			},
+		},
+	},
+} satisfies Meta<typeof WizardSteps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		current: 0,
+		type: 'itsa-panel',
+		items: [
+			{ title: 'Cliente', status: 'process' },
+			{ title: 'Vehículo', status: 'wait' },
+			{ title: 'Datos', status: 'wait' },
+			{ title: 'Finalizar', status: 'wait' },
+		],
+	},
+};
+
+export const Interactive: Story = {
+	args: {
+		current: 0,
+		type: 'itsa-panel',
+		items: [],
+	},
+	render: () => {
+		const [currentStep, setCurrentStep] = useState(0);
+
+		const steps: StepsProps['items'] = [
+			{
+				title: 'Cliente',
+				status: currentStep > 0 ? 'finish' : currentStep === 0 ? 'process' : 'wait',
+			},
+			{
+				title: 'Vehículo',
+				status: currentStep > 1 ? 'finish' : currentStep === 1 ? 'process' : 'wait',
+			},
+			{
+				title: 'Datos',
+				status: currentStep > 2 ? 'finish' : currentStep === 2 ? 'process' : 'wait',
+			},
+			{
+				title: 'Finalizar',
+				status: currentStep === 3 ? 'process' : 'wait',
+			},
+		];
+
+		const handleStepChange = (step: number) => {
+			console.log('Navegando al paso:', step);
+			setCurrentStep(step);
+		};
+
+		return (
+			<div className="space-y-6">
+				<WizardSteps type="itsa-panel" current={currentStep} items={steps} onChange={handleStepChange} />
+
+				<div className="bg-white p-6 rounded-lg shadow">
+					<h3 className="text-lg font-semibold mb-4">Paso Actual: {currentStep + 1}</h3>
+					<p className="text-gray-600">Contenido del paso "{steps[currentStep]?.title}"</p>
+
+					<div className="mt-6 flex gap-4">
+						<button
+							onClick={() => setCurrentStep(prev => Math.max(0, prev - 1))}
+							disabled={currentStep === 0}
+							className="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300 disabled:opacity-50 disabled:cursor-not-allowed"
+						>
+							Anterior
+						</button>
+						<button
+							onClick={() => setCurrentStep(prev => Math.min(3, prev + 1))}
+							disabled={currentStep === 3}
+							className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed"
+						>
+							Siguiente
+						</button>
+					</div>
+				</div>
+			</div>
+		);
+	},
+};
+
+export const WithError: Story = {
+	args: {
+		current: 1,
+		type: 'itsa-panel',
+		items: [
+			{ title: 'Información', status: 'finish' },
+			{ title: 'Validación', status: 'error' },
+			{ title: 'Confirmación', status: 'wait' },
+			{ title: 'Completado', status: 'wait' },
+		],
+	},
+};
+
+export const ManySteps: Story = {
+	args: {
+		current: 2,
+		type: 'itsa-panel',
+		items: [
+			{ title: 'Paso 1', status: 'finish' },
+			{ title: 'Paso 2', status: 'finish' },
+			{ title: 'Paso 3', status: 'process' },
+			{ title: 'Paso 4', status: 'wait' },
+			{ title: 'Paso 5', status: 'wait' },
+			{ title: 'Paso 6', status: 'wait' },
+		],
+	},
+};
+
+export const CustomSize: Story = {
+	args: {
+		current: 1,
+		type: 'itsa-panel',
+		height: 60,
+		arrowWidth: 32,
+		items: [
+			{ title: 'Inicio', status: 'finish' },
+			{ title: 'Proceso', status: 'process' },
+			{ title: 'Final', status: 'wait' },
+		],
+	},
+};
+
+export const Compact: Story = {
+	args: {
+		current: 0,
+		type: 'itsa-panel',
+		height: 36,
+		arrowWidth: 18,
+		items: [
+			{ title: 'Step 1', status: 'process' },
+			{ title: 'Step 2', status: 'wait' },
+			{ title: 'Step 3', status: 'wait' },
+		],
+	},
+};
+
+export const LongTitles: Story = {
+	args: {
+		current: 1,
+		type: 'itsa-panel',
+		items: [
+			{ title: 'Información del Cliente y Datos Personales', status: 'finish' },
+			{ title: 'Selección de Vehículo y Configuración', status: 'process' },
+			{ title: 'Verificación de Documentos y Requisitos', status: 'wait' },
+			{ title: 'Finalización y Confirmación del Proceso', status: 'wait' },
+		],
+	},
+};
+
+export const TypeDefault: Story = {
+	args: {
+		current: 1,
+		type: 'default',
+		items: [
+			{ title: 'Información', status: 'finish', description: 'Datos básicos' },
+			{ title: 'Validación', status: 'process', description: 'Revisión' },
+			{ title: 'Confirmación', status: 'wait', description: 'Verificación final' },
+			{ title: 'Completado', status: 'wait', description: 'Proceso terminado' },
+		],
+	},
+};
+
+export const TypeNavigation: Story = {
+	args: {
+		current: 2,
+		type: 'navigation',
+		items: [
+			{ title: 'Paso 1', status: 'finish' },
+			{ title: 'Paso 2', status: 'finish' },
+			{ title: 'Paso 3', status: 'process' },
+			{ title: 'Paso 4', status: 'wait' },
+		],
+	},
+};
+
+export const TypeInline: Story = {
+	args: {
+		current: 0,
+		type: 'inline',
+		items: [
+			{ title: 'Inicio', status: 'process' },
+			{ title: 'Proceso', status: 'wait' },
+			{ title: 'Final', status: 'wait' },
+		],
+	},
+};


### PR DESCRIPTION

## Descripción

Implementación del componente WizardSteps para gestionar navegación por pasos en la aplicación, con soporte para múltiples estilos de visualización incluyendo un diseño chevron personalizado tipo ITSA Panel.

## Resumen de los cambios

- Componente WizardSteps
  - Componente base con soporte para tipos: 'default', 'navigation', 'inline' e 'itsa-panel'.
  - Tipo 'itsa-panel': diseño personalizado con forma de chevron/flecha encajable, separación visible entre pasos.
  - Props configurables: altura (height), ancho de flecha (arrowWidth), contenedor opcional (withContainer).
  - Sistema de estilos separado en WizardSteps.styles.ts para mejor mantenimiento.
- Estilos y Responsive
  - Integración con colores del theme de Tailwind (gray-250, alpine-400, primary-800, etc.).
  - Diseño responsivo optimizado: layout vertical en móvil con separación clara entre pasos.
  - Estados visuales: wait, process, finish, error con colores diferenciados.
  - Hover interactivo: cambio de color del texto al pasar el cursor.
- Documentación
  - Storybook con 10 ejemplos: Default, Interactive, WithError, ManySteps, CustomSize, Compact, LongTitles, TypeDefault, TypeNavigation, TypeInline.
  - Documentación detallada de props con tipos y valores por defecto.
  - Ejemplos interactivos con navegación funcional entre pasos.

## Tipo de cambio
- [ ] Bugfix
- [x] Nueva característica
- [x] Mejora
- [ ] Otro

## Checklist
- [x] Compilación correcta
- [x] Documentación actualizada 
- [x] He seguido las convenciones de estilo del código.
- [x] He realizado pruebas que validan estos cambios.

## Notas

- El tipo 'itsa-panel' es el diseño personalizado con chevrons; los demás tipos (default, navigation, inline) utilizan los estilos nativos de Ant Design.
- El componente genera IDs únicos por instancia para evitar conflictos de estilos cuando se usan múltiples WizardSteps en la misma página.