### PR TITLE
[cr][668] Library Components: support for customization of the detail view tag

### DIFF
--- a/src/components/DetailView/renderers/BadgeRenderer.tsx
+++ b/src/components/DetailView/renderers/BadgeRenderer.tsx
@@ -34,7 +34,11 @@ export const BadgeRenderer = ({ value, data, config }: BadgeRendererProps) => {
 
 	return (
 		<div className="flex items-start">
-			<TagStatus status={booleanValue} />
+			<TagStatus 
+				status={booleanValue} 
+				labelTrue={config.badgeLabels?.true}
+				labelFalse={config.badgeLabels?.false}
+			/>
 		</div>
 	);
 };

--- a/src/components/DetailView/schema/SchemaBuilder.ts
+++ b/src/components/DetailView/schema/SchemaBuilder.ts
@@ -42,6 +42,7 @@ export class SectionBuilder<TData = Record<string, unknown>> {
 			tableConfig: options?.tableConfig,
 			galleryConfig: options?.galleryConfig,
 			customRenderer: options?.customRenderer,
+			badgeLabels: options?.badgeLabels,
 			emptyText: options?.emptyText,
 			copyable: options?.copyable,
 			showTooltip: options?.showTooltip,
@@ -93,8 +94,17 @@ export class SectionBuilder<TData = Record<string, unknown>> {
 		});
 	}
 
-	badge(key: keyof TData & string, label: string, options?: Omit<FieldBuilderOptions<TData>, 'type'>): this {
-		return this.field(key, label, { ...options, type: 'badge' });
+	badge(
+		key: keyof TData & string, 
+		label: string, 
+		labels?: { true: string; false: string },
+		options?: Omit<FieldBuilderOptions<TData>, 'type' | 'badgeLabels'>
+	): this {
+		return this.field(key, label, { 
+			...options, 
+			type: 'badge',
+			badgeLabels: labels 
+		});
 	}
 
 	link(key: keyof TData & string, label: string, options?: Omit<FieldBuilderOptions<TData>, 'type'>): this {

--- a/src/components/DetailView/schema/types.ts
+++ b/src/components/DetailView/schema/types.ts
@@ -65,6 +65,7 @@ export interface FieldConfig<TData = Record<string, unknown>> {
 	tableConfig?: TableConfig;
 	galleryConfig?: GalleryConfig;
 	customRenderer?: CustomRenderer<unknown, TData>;
+	badgeLabels?: { true: string; false: string };
 	emptyText?: string;
 	copyable?: boolean;
 	showTooltip?: boolean;

--- a/src/storybook/components/DetailView.stories.tsx
+++ b/src/storybook/components/DetailView.stories.tsx
@@ -71,7 +71,7 @@ export const Basic: Story = {
 					.field('itemCode', 'Código')
 					.field('itemSuffix', 'Sufijo')
 					.field('brandName', 'Marca')
-					.badge('isActive', 'Estado')
+					.badge('isActive', 'Estado', { true: 'Sí', false: 'No' })
 			)
 			.section('Especificaciones', s =>
 				s


### PR DESCRIPTION
## Descripción

Implementación de soporte para personalizar los textos de las etiquetas (badges) en el componente DetailView, permitiendo especificar labels customizados para estados booleanos en lugar de usar únicamente "Activo"/"Inactivo".

## Resumen de los cambios

- DetailView - Schema Types
  - Agregada prop badgeLabels?: { true: string; false: string } al FieldConfig para permitir customización de textos.
  - Integración con FieldBuilderOptions para soporte en configuración declarativa.
- BadgeRenderer
  - Actualizado para pasar labelTrue y labelFalse al componente TagStatus desde config.badgeLabels.
  - Mantiene retrocompatibilidad: usa labels por defecto si no se especifican customizados.
- SchemaBuilder
  - Método badge() actualizado con parámetro labels opcional para facilitar configuración.
  - Sintaxis simplificada: .badge('disponible', 'Disponibilidad', { true: 'Disponible', false: 'No disponible' }).
  - Soporte para opciones adicionales (span, formatter, etc.) junto con labels personalizados.

## Tipo de cambio
- [ ] Bugfix
- [x] Nueva característica
- [x] Mejora
- [ ] Otro

## Checklist
- [x] Compilación correcta
- [ ] Documentación actualizada 
- [x] He seguido las convenciones de estilo del código.
- [x] He realizado pruebas que validan estos cambios.

## Notas

- Los labels son completamente opcionales: si no se especifican, mantiene el comportamiento por defecto ("Activo"/"Inactivo").
- Retrocompatibilidad garantizada: schemas existentes funcionan sin modificaciones.
- Ejemplos de uso: "Disponible"/"No disponible", "Sí"/"No", "Habilitado"/"Deshabilitado", según el contexto del dominio.