### PR TITLE
[ft][671] Library Components: new styles for the steps and collapsed components

### DIFF
--- a/src/components/Collapse/Collapse.styles.ts
+++ b/src/components/Collapse/Collapse.styles.ts
@@ -1,0 +1,117 @@
+export const getCollapseCardStyles = (): string => `
+	:root {
+		--collapse-primary: #EA3B48;
+		--collapse-gradient-start: #fff0f1;
+		--collapse-gradient-end: white;
+		--collapse-border-active: #ffc2c6;
+		--collapse-border-inactive: #e0e0e0;
+		--collapse-text-active: #EA3B48;
+		--collapse-text-inactive: #000000;
+		--collapse-badge-bg-active: #EA3B48;
+		--collapse-badge-text-active: #FFFFFF;
+		--collapse-badge-bg-inactive: #F4F8FB;
+		--collapse-badge-text-inactive: #4A5565;
+		--collapse-bg-white: white;
+		--collapse-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.08);
+		--collapse-border-radius: 12px;
+	}
+
+	.itsa-collapse--card.ant-collapse {
+		background: transparent !important;
+		border: none !important;
+	}
+
+	.itsa-collapse--card.ant-collapse > .ant-collapse-item {
+		margin-bottom: 16px !important;
+		background: var(--collapse-bg-white) !important;
+		border-radius: var(--collapse-border-radius) !important;
+		border: 1px solid var(--collapse-border-inactive) !important;
+		box-shadow: var(--collapse-shadow) !important;
+		overflow: hidden !important;
+	}
+
+	.itsa-collapse--card.ant-collapse > .ant-collapse-item.ant-collapse-item-active {
+		background: linear-gradient(to bottom, var(--collapse-gradient-start) 0%, var(--collapse-gradient-end) 30%) !important;
+		border: 1.5px solid var(--collapse-border-active) !important;
+	}
+
+	.itsa-collapse--card.ant-collapse > .ant-collapse-item:last-child {
+		margin-bottom: 0 !important;
+	}
+
+	.itsa-collapse--card.ant-collapse > .ant-collapse-item > .ant-collapse-header {
+		background: transparent !important;
+		border-radius: var(--collapse-border-radius) var(--collapse-border-radius) 0 0 !important;
+		border-bottom: none !important;
+		padding: 20px 20px !important;
+		font-weight: 600 !important;
+		font-size: 16px !important;
+	}
+
+	.itsa-collapse--card.ant-collapse > .ant-collapse-item > .ant-collapse-header .ant-collapse-header-text {
+		color: var(--collapse-text-inactive) !important;
+	}
+
+	.itsa-collapse--card.ant-collapse > .ant-collapse-item.ant-collapse-item-active > .ant-collapse-header .ant-collapse-header-text {
+		color: var(--collapse-text-active) !important;
+	}
+
+	.itsa-collapse--card.ant-collapse > .ant-collapse-item > .ant-collapse-header .ant-collapse-expand-icon {
+		color: var(--collapse-text-inactive) !important;
+	}
+
+	.itsa-collapse--card.ant-collapse > .ant-collapse-item.ant-collapse-item-active > .ant-collapse-header .ant-collapse-expand-icon {
+		color: var(--collapse-text-active) !important;
+	}
+
+	.itsa-collapse--card.ant-collapse > .ant-collapse-item > .ant-collapse-header .ant-collapse-expand-icon svg {
+		color: var(--collapse-text-inactive) !important;
+		fill: var(--collapse-text-inactive) !important;
+	}
+
+	.itsa-collapse--card.ant-collapse > .ant-collapse-item.ant-collapse-item-active > .ant-collapse-header .ant-collapse-expand-icon svg {
+		color: var(--collapse-text-active) !important;
+		fill: var(--collapse-text-active) !important;
+	}
+
+	.itsa-collapse--card.ant-collapse > .ant-collapse-item.ant-collapse-item-active > .ant-collapse-header {
+		border-radius: var(--collapse-border-radius) var(--collapse-border-radius) 0 0 !important;
+	}
+
+	.itsa-collapse--card.ant-collapse > .ant-collapse-item:not(.ant-collapse-item-active) > .ant-collapse-header {
+		border-radius: var(--collapse-border-radius) !important;
+		border-bottom: none !important;
+	}
+
+	.itsa-collapse--card.ant-collapse > .ant-collapse-item > .ant-collapse-content {
+		background: transparent !important;
+		border-radius: 0 0 var(--collapse-border-radius) var(--collapse-border-radius) !important;
+		border-top: none !important;
+	}
+
+	.itsa-collapse--card.ant-collapse > .ant-collapse-item > .ant-collapse-content > .ant-collapse-content-box {
+		background: transparent !important;
+		padding: 20px !important;
+		padding-top: 0 !important;
+	}
+
+	.itsa-collapse--card.ant-collapse .ant-collapse-content-box {
+		background: transparent !important;
+	}
+
+	.itsa-collapse-step-badge {
+		display: inline-block;
+		background: var(--collapse-badge-bg-inactive) !important;
+		color: var(--collapse-badge-text-inactive) !important;
+		padding: 4px 12px;
+		border-radius: var(--collapse-border-radius);
+		font-size: 10px;
+		font-weight: 400;
+		margin-left: 12px;
+	}
+
+	.itsa-collapse--card.ant-collapse > .ant-collapse-item.ant-collapse-item-active .itsa-collapse-step-badge {
+		background: var(--collapse-badge-bg-active) !important;
+		color: var(--collapse-badge-text-active) !important;
+	}
+`;

--- a/src/components/Collapse/Collapse.tsx
+++ b/src/components/Collapse/Collapse.tsx
@@ -1,6 +1,45 @@
 import { Collapse as AntCollapse, CollapseProps } from 'antd';
+import { useMemo } from 'react';
+import { getCollapseCardStyles } from './Collapse.styles';
 
-export const Collapse = ({ className, size = 'small', bordered = false, ...rest }: CollapseProps) => {
-    const mergedClassName = ['itsa-collapse--compact', className].filter(Boolean).join(' ');
-    return <AntCollapse className={mergedClassName} size={size} bordered={bordered} {...rest} />;
+export interface ICollapseProps extends CollapseProps {
+	variant?: 'default' | 'card';
+	showSteps?: boolean;
+}
+
+export const Collapse = ({ className, size = 'small', bordered = false, variant = 'default', showSteps = false, items, ...rest }: ICollapseProps) => {
+	const variantClass = variant === 'card' ? 'itsa-collapse--card' : '';
+	const mergedClassName = ['itsa-collapse--compact', variantClass, className].filter(Boolean).join(' ');
+	
+	const enhancedItems = useMemo(() => {
+		if (variant === 'card' && showSteps && items) {
+			const totalSteps = items.length;
+			return items.map((item, index) => ({
+				...item,
+				label: (
+					<div style={{ display: 'flex', alignItems: 'center' }}>
+						<span>{item.label}</span>
+                        <span className="itsa-collapse-step-badge">
+							Paso {index + 1} de {totalSteps}
+						</span>
+					</div>
+				),
+			}));
+		}
+		return items;
+	}, [variant, showSteps, items]);
+	
+	return (
+		<>
+			{variant === 'card' && <style>{getCollapseCardStyles()}</style>}
+			<AntCollapse 
+				className={mergedClassName} 
+				size={size} 
+				bordered={bordered} 
+				items={enhancedItems} 
+				expandIconPosition="end"
+				{...rest} 
+			/>
+		</>
+	);
 };

--- a/src/components/WizardSteps/WizardSteps.default.styles.ts
+++ b/src/components/WizardSteps/WizardSteps.default.styles.ts
@@ -1,0 +1,77 @@
+export const getWizardStepsDefaultStyles = (): string => `
+	.itsa-wizard-steps .ant-steps-item-process > .ant-steps-item-container > .ant-steps-item-icon {
+		background-color: #EA3B48 !important;
+		border-color: #EA3B48 !important;
+	}
+
+	.itsa-wizard-steps .ant-steps-item-wait > .ant-steps-item-container > .ant-steps-item-icon {
+		background-color: #F4F8FB !important;
+		border-color: #d9d9d9 !important;
+	}
+
+	.itsa-wizard-steps .ant-steps-item-finish > .ant-steps-item-container > .ant-steps-item-icon {
+		background-color: #EA3B48 !important;
+		border-color: #EA3B48 !important;
+	}
+
+	.itsa-wizard-steps .ant-steps-item-finish .ant-steps-item-icon > .ant-steps-icon {
+		color: #FFFFFF !important;
+	}
+
+	.itsa-wizard-steps .ant-steps-item-finish > .ant-steps-item-container > .ant-steps-item-content > .ant-steps-item-title::after,
+	.itsa-wizard-steps .ant-steps-item-finish > .ant-steps-item-tail::after,
+	.itsa-wizard-steps .ant-steps-item-finish .ant-steps-item-tail::after,
+	.itsa-wizard-steps.ant-steps-vertical .ant-steps-item-finish .ant-steps-item-tail::after {
+		background-color: #EA3B48 !important;
+	}
+
+	.itsa-wizard-steps .ant-steps-item-process > .ant-steps-item-container > .ant-steps-item-content > .ant-steps-item-title {
+		color: #EA3B48 !important;
+	}
+
+	.itsa-wizard-steps .ant-steps-item:hover .ant-steps-item-icon {
+		border-color: #EA3B48 !important;
+	}
+
+	.itsa-wizard-steps .ant-steps-item:hover .ant-steps-item-icon .ant-steps-icon {
+		color: #EA3B48 !important;
+	}
+
+	.itsa-wizard-steps .ant-steps-item-finish:hover .ant-steps-item-icon .ant-steps-icon,
+	.itsa-wizard-steps .ant-steps-item-process:hover .ant-steps-item-icon .ant-steps-icon {
+		color: #FFFFFF !important;
+	}
+
+	.itsa-wizard-steps .ant-steps-item:hover .ant-steps-item-title {
+		color: #EA3B48 !important;
+	}
+
+	.itsa-wizard-steps.ant-steps-navigation .ant-steps-item::after {
+		border-color: #EA3B48 !important;
+	}
+
+	.itsa-wizard-steps.ant-steps-navigation .ant-steps-item-active::after {
+		border-left-color: #EA3B48 !important;
+	}
+
+	.itsa-wizard-steps.ant-steps-navigation .ant-steps-item-container:hover {
+		background-color: rgba(234, 59, 72, 0.08) !important;
+	}
+
+	.itsa-wizard-steps.ant-steps-inline .ant-steps-item-container:hover {
+		color: #EA3B48 !important;
+	}
+
+	.itsa-wizard-steps.ant-steps-vertical .ant-steps-item-content {
+		margin-top: 2px !important;
+		margin-inline-start: 0 !important;
+	}
+
+	.itsa-wizard-steps.ant-steps-label-vertical .ant-steps-item-content {
+		margin-top: 4px !important;
+	}
+
+	.itsa-wizard-steps.ant-steps-vertical .ant-steps-item-icon {
+		margin-inline-end: 0 !important;
+	}
+`;

--- a/src/components/WizardSteps/WizardSteps.tsx
+++ b/src/components/WizardSteps/WizardSteps.tsx
@@ -1,5 +1,6 @@
 import { Steps, type StepsProps } from 'antd';
 import { getWizardStepsStyles } from './WizardSteps.styles';
+import { getWizardStepsDefaultStyles } from './WizardSteps.default.styles';
 
 export interface IWizardStepsProps {
 	current: number;
@@ -10,6 +11,8 @@ export interface IWizardStepsProps {
 	height?: number;
 	arrowWidth?: number;
 	withContainer?: boolean;
+	containerPadding?: string;
+	labelPlacement?: 'horizontal' | 'vertical';
 }
 
 export const WizardSteps = ({ 
@@ -20,7 +23,9 @@ export const WizardSteps = ({
 	type = 'default',
 	height = 48, 
 	arrowWidth = 24,
-	withContainer = true
+	withContainer = true,
+	containerPadding = 'p-2',
+	labelPlacement = 'horizontal'
 }: IWizardStepsProps) => {
 	const containerId = `wizard-steps-${Math.random().toString(36).substr(2, 9)}`;
 	const isItsaPanel = type === 'itsa-panel';
@@ -32,9 +37,19 @@ export const WizardSteps = ({
 
 	if (!isItsaPanel) {
 		return (
-			<div className={className}>
-				<Steps type={type} current={current} items={items} onChange={onChange} />
-			</div>
+			<>
+				<style>{getWizardStepsDefaultStyles()}</style>
+				<div className={withContainer ? `bg-white ${containerPadding} rounded-lg shadow-sm ${className}` : className}>
+					<Steps 
+						className="itsa-wizard-steps" 
+						type={type} 
+						current={current} 
+						items={items} 
+						onChange={onChange}
+						labelPlacement={labelPlacement}
+					/>
+				</div>
+			</>
 		);
 	}
 
@@ -43,7 +58,7 @@ export const WizardSteps = ({
 			<style>{getWizardStepsStyles(containerId, arrowWidth)}</style>
 			<div 
 				id={containerId} 
-				className={withContainer ? `bg-white p-2 rounded-lg shadow-sm ${className}` : className}
+				className={withContainer ? `bg-white ${containerPadding} rounded-lg shadow-sm ${className}` : className}
 				style={containerStyles}
 			>
 				<Steps className="wizard-steps" current={current} items={items} onChange={onChange} />

--- a/src/storybook/components/Collapse.stories.tsx
+++ b/src/storybook/components/Collapse.stories.tsx
@@ -10,11 +10,33 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					'Component Collapse usando Ant Design.\n\n👉 [Ver documentación oficial](https://ant.design/components/Collapse)',
+					'Component Collapse usando Ant Design con soporte para variantes.\n\n' +
+					'**Variantes disponibles:**\n' +
+					'- `default`: Estilo compacto estándar\n' +
+					'- `card`: Paneles individuales con estilo de tarjeta, separación y sombras\n\n' +
+					'👉 [Ver documentación oficial](https://ant.design/components/Collapse)',
 			},
 		},
 	},
-	argTypes: {},
+	argTypes: {
+		variant: {
+			control: { type: 'select' },
+			options: ['default', 'card'],
+			description: 'Variante visual del Collapse',
+			table: {
+				type: { summary: 'string' },
+				defaultValue: { summary: 'default' },
+			},
+		},
+		showSteps: {
+			control: { type: 'boolean' },
+			description: 'Mostrar indicador de pasos (solo para variant="card")',
+			table: {
+				type: { summary: 'boolean' },
+				defaultValue: { summary: 'false' },
+			},
+		},
+	},
 };
 
 export default meta;
@@ -42,6 +64,100 @@ export const Default: Story = {
 				key: '3',
 				label: 'This is panel header 3',
 				children: <p>text 3</p>,
+			},
+		],
+	},
+};
+
+export const CardVariant: Story = {
+	args: {
+		variant: 'card',
+		showSteps: true,
+		defaultActiveKey: ['1'],
+		items: [
+			{
+				key: '1',
+				label: 'Información General',
+				children: (
+					<div>
+						<p className="mb-2">
+							<strong>Documento Identidad:</strong> 1234567890
+						</p>
+						<p className="mb-2">
+							<strong>Nombre:</strong> Carlos Alberto
+						</p>
+						<p className="mb-2">
+							<strong>Apellido:</strong> Mendoza García
+						</p>
+						<p>
+							<strong>Email:</strong> carlos.mendoza@ejemplo.com
+						</p>
+					</div>
+				),
+			},
+			{
+				key: '2',
+				label: 'Información de Contacto',
+				children: (
+					<div>
+						<p className="mb-2">
+							<strong>Teléfono:</strong> +593 98 765 4321
+						</p>
+						<p className="mb-2">
+							<strong>Dirección:</strong> Av. Principal 123
+						</p>
+						<p>
+							<strong>Ciudad:</strong> Quito
+						</p>
+					</div>
+				),
+			},
+			{
+				key: '3',
+				label: 'Información Adicional',
+				children: (
+					<div>
+						<p className="mb-2">
+							<strong>Agencia:</strong> Cuenca
+						</p>
+						<p className="mb-2">
+							<strong>Vendedor:</strong> Juan Pérez
+						</p>
+						<p>
+							<strong>Tipo Persona:</strong> Natural
+						</p>
+					</div>
+				),
+			},
+		],
+	},
+};
+
+export const CardVariantMultiple: Story = {
+	args: {
+		variant: 'card',
+		showSteps: true,
+		accordion: false,
+		items: [
+			{
+				key: '1',
+				label: 'Sección A - Información General',
+				children: <p>Contenido con información general de la aplicación y configuraciones básicas.</p>,
+			},
+			{
+				key: '2',
+				label: 'Sección B - Detalles Técnicos',
+				children: <p>Especificaciones técnicas, versiones y dependencias del sistema.</p>,
+			},
+			{
+				key: '3',
+				label: 'Sección C - Documentación',
+				children: <p>Enlaces a documentación, guías de uso y recursos adicionales para desarrolladores.</p>,
+			},
+			{
+				key: '4',
+				label: 'Sección D - Soporte',
+				children: <p>Información de contacto, canales de soporte y recursos de ayuda disponibles.</p>,
 			},
 		],
 	},

--- a/src/storybook/components/WizardSteps.stories.tsx
+++ b/src/storybook/components/WizardSteps.stories.tsx
@@ -227,6 +227,7 @@ export const TypeDefault: Story = {
 	args: {
 		current: 1,
 		type: 'default',
+		labelPlacement: "vertical",
 		items: [
 			{ title: 'Información', status: 'finish', description: 'Datos básicos' },
 			{ title: 'Validación', status: 'process', description: 'Revisión' },


### PR DESCRIPTION
## Descripción

Implementación de estilos personalizados ITSA para los componentes WizardSteps y Collapse, incluyendo separación de estilos por variantes, nuevos estados visuales y props de configuración para mayor flexibilidad.

## Resumen de los cambios

- **WizardSteps**
  - Separación de estilos: creado WizardSteps.default.styles.ts para variantes default/navigation/inline, manteniendo WizardSteps.styles.ts solo para itsa-panel.
  - Aplicados colores ITSA: rojo (#EA3B48) para estados activos/completados, gris (#F4F8FB) para estados pendientes.
  - Nueva prop labelPlacement: control de posición del texto (horizontal/vertical).
  - Nueva prop containerPadding: personalización del padding del contenedor.
  - Prop withContainer ahora afecta tanto a variantes default como itsa-panel.
  - Hovers optimizados: iconos blancos en steps activos/completados mantienen contraste sobre fondo rojo.
  - Líneas de progreso rojas en todos los modos (horizontal y vertical).

- **Collapse**
  - Nueva variante card: paneles con estilos de tarjeta, degradados y estados visuales diferenciados.
  - Estilos separados en Collapse.styles.ts con variables CSS organizadas en :root.
  - Estados visuales claros:
    - Inactivo: fondo blanco, texto/flecha negro, borde gris.
    - Activo: degradado rosa a blanco, texto/flecha rojo, borde rosa.
  - Nueva prop showSteps: muestra indicador "Paso X de Y" con badge que cambia según estado (activo: rojo/blanco, inactivo: gris).
  - Flecha posicionada al lado derecho con expandIconPosition="end".
  - Sin separación visible entre header y contenido, degradado fluido.

## Tipo de cambio
- [ ] Bugfix
- [x] Nueva característica
- [x] Mejora
- [ ] Otro

## Checklist
- [x] Compilación correcta
- [x] Documentación actualizada 
- [x] He seguido las convenciones de estilo del código.
- [x] He realizado pruebas que validan estos cambios.

## Notas

- Los estilos CSS inline se inyectan dinámicamente para garantizar exportación correcta del paquete.
- WizardSteps mantiene retrocompatibilidad: variantes default funcionan sin cambios en el uso, solo mejoran visualmente.
- Collapse variant="default" no se ve afectado; la nueva funcionalidad es opt-in con variant="card".
- Variables CSS en Collapse facilitan futuras personalizaciones de colores desde un solo punto.