### PR TITLE
[ft][753] Library Components: size adjustment in detail preview

### DIFF
--- a/src/components/DetailView/DetailSection.tsx
+++ b/src/components/DetailView/DetailSection.tsx
@@ -152,7 +152,8 @@ export const DetailSection = <TData extends object = object>({
 		<Card
 			title={<span className="text-sm font-normal">{section.title}</span>}
 			extra={section.extra}
-			className={`bg-gray-50 ${section.className || ''}`}
+			className={`bg-gray-50 h-full ${section.className || ''}`}
+			style={{ display: 'flex', flexDirection: 'column', height: '100%' }}
 			styles={{
 				header: {
 					borderTop: '1px solid #E5E7EB',
@@ -160,13 +161,14 @@ export const DetailSection = <TData extends object = object>({
 					borderRight: '1px solid #E5E7EB',
 					borderBottom: 'none',
 				},
-				body: { 
-                    paddingTop: '0px', 
-                    borderTop: 'none',
+				body: {
+					flex: 1,
+					paddingTop: '0px',
+					borderTop: 'none',
 					borderLeft: '1px solid #E5E7EB',
 					borderRight: '1px solid #E5E7EB',
-					borderBottom: '1px solid #E5E7EB', 
-                },
+					borderBottom: '1px solid #E5E7EB',
+				},
 			}}
 		>
 			{content}

--- a/src/components/DetailView/DetailView.tsx
+++ b/src/components/DetailView/DetailView.tsx
@@ -22,7 +22,7 @@ export const DetailView = <T extends object = object>({
 
 	if (isLoading) {
 		return (
-			<div className="grid grid-cols-1 lg:grid-cols-2 gap-4 px-2">
+			<div className="grid grid-cols-1 md:grid-cols-2 gap-4 px-2">
 				{Array.from({ length: schema.sections.length || 3 }).map((_, index) => (
 					<Card key={index} loading className="bg-gray-50" />
 				))}
@@ -66,11 +66,11 @@ export const DetailView = <T extends object = object>({
 			{visibleSections.length === 0 ? (
 				<Empty description="No hay secciones para mostrar" />
 			) : (
-				<div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+				<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
 					{visibleSections.map((section, index) => (
 						<div
 							key={`${section.title}-${index}`}
-							className={section.fullWidth ? 'lg:col-span-2' : ''}
+							className={`h-full ${section.fullWidth ? 'md:col-span-2' : ''}`}
 						>
 							<DetailSection
 								section={section}


### PR DESCRIPTION
## Descripción

Ajustes en el componente DetailView de la librería para corregir el comportamiento visual de las tarjetas en el layout de dos columnas: igualación de alturas entre cards de la misma fila y corrección del breakpoint responsivo.

## Resumen de los cambios

- DetailView
  - Breakpoint del grid de dos columnas bajado de lg (1024px) a md (768px), permitiendo el layout de dos columnas en pantallas medianas.
  - El mismo ajuste aplicado al skeleton de carga y a las secciones con fullWidth.
  - Cada tarjeta ahora recibe h-full en su contenedor para que todas las cards de una misma fila tengan igual altura.

- DetailSection
  - El componente Card configurado como flex column con height: 100% para que su estructura interna se estire correctamente.
  - El body del Card con flex: 1 para ocupar todo el espacio disponible, garantizando que el borde inferior siempre quede alineado con las cards vecinas.

## Tipo de cambio
- [ ] Bugfix
- [ ] Nueva característica
- [x] Mejora
- [ ] Otro

## Checklist
- [x] Compilación correcta
- [ ] Documentación actualizada
- [x] He seguido las convenciones de estilo del código.
- [ ] He realizado pruebas que validan estos cambios.

## Notas

- El ajuste de altura usa flexbox en el Card de Ant Design vía la prop style y styles.body, ya que Ant Design no expone esta configuración por clase.
- El breakpoint md cubre la mayoría de los casos de uso en los módulos del sistema (tablets y escritorio), mientras que lg dejaba el layout en una sola columna en pantallas medianas.