### PR TITLE
fx: update FormInputDatePicker

### DIFF
--- a/src/components/FormInputDatePicker/index.tsx
+++ b/src/components/FormInputDatePicker/index.tsx
@@ -12,23 +12,24 @@ dayjs.extend(customParseFormat);
 
 const hasTimeTokens = (format: string) => format.includes('HH') || format.includes('mm') || format.includes('ss');
 
-const getShowTimeConfig = (format: string): DatePickerProps['showTime'] => {
+type TMinuteStep = DatePickerProps['minuteStep'];
+
+const getShowTimeConfig = (format: string, minuteStep?: TMinuteStep): DatePickerProps['showTime'] => {
 	if (!hasTimeTokens(format)) {
 		return false;
 	}
 
 	if (format.includes('ss')) {
-		return { format: 'HH:mm:ss' };
+		return { format: 'HH:mm:ss', minuteStep };
 	}
 
-	return { format: 'HH:mm' };
+	return { format: 'HH:mm', minuteStep };
 };
 
 export interface IInputProps<TFieldValues extends FieldValues>
 	extends Omit<DatePickerProps, 'value' | 'onChange' | 'defaultValue' | 'format'> {
 	name: Path<TFieldValues>;
 	label: string;
-	showCaracteres?: boolean;
 	control: Control<TFieldValues>;
 	placeholder?: string;
 	optional?: boolean;
@@ -45,11 +46,12 @@ const FormInputDatePickerComponent = <TFieldValues extends FieldValues>({
 	format = EDateMaskFormat.YYYYMMDD,
 	disabled = false,
 	allowClear = true,
+	minuteStep,
 	...rest
 }: IInputProps<TFieldValues>) => {
 	const id = useId();
 	const errId = `${id}-error`;
-	const resolvedShowTime = getShowTimeConfig(format);
+	const resolvedShowTime = getShowTimeConfig(format, minuteStep);
 
 	return (
 		<Controller

--- a/src/index.css
+++ b/src/index.css
@@ -894,12 +894,12 @@
   max-width: 100%;
 }
 
-.max-w-xl{
-  max-width: 36rem;
-}
-
 .max-w-md{
   max-width: 28rem;
+}
+
+.max-w-xl{
+  max-width: 36rem;
 }
 
 .flex-1{
@@ -959,6 +959,12 @@
 
 .resize{
   resize: both;
+}
+
+.appearance-none{
+  -webkit-appearance: none;
+     -moz-appearance: none;
+          appearance: none;
 }
 
 .grid-cols-1{
@@ -1393,16 +1399,6 @@
 .border-red-600{
   --tw-border-opacity: 1;
   border-color: rgb(229 57 53 / var(--tw-border-opacity, 1));
-}
-
-.border-blue-200{
-  --tw-border-opacity: 1;
-  border-color: rgb(176 238 255 / var(--tw-border-opacity, 1));
-}
-
-.border-red-200{
-  --tw-border-opacity: 1;
-  border-color: rgb(255 201 200 / var(--tw-border-opacity, 1));
 }
 
 .\!border-b-gray-200{
@@ -1934,16 +1930,6 @@
   color: rgb(255 255 255 / var(--tw-text-opacity, 1));
 }
 
-.text-blue-700{
-  --tw-text-opacity: 1;
-  color: rgb(34 121 162 / var(--tw-text-opacity, 1));
-}
-
-.text-red-700{
-  --tw-text-opacity: 1;
-  color: rgb(190 27 23 / var(--tw-text-opacity, 1));
-}
-
 .line-through{
   text-decoration-line: line-through;
 }
@@ -2012,6 +1998,11 @@
   --tw-shadow: 0 1px 2px 0 rgba(38, 50, 56, 0.50);
   --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.outline-none{
+  outline: 2px solid transparent;
+  outline-offset: 2px;
 }
 
 .outline{
@@ -2615,11 +2606,6 @@ body,
   border-color: rgb(253 111 108 / var(--tw-border-opacity, 1));
 }
 
-.hover\:border-blue-300:hover{
-  --tw-border-opacity: 1;
-  border-color: rgb(136 234 255 / var(--tw-border-opacity, 1));
-}
-
 .hover\:\!bg-gray-50:hover{
   --tw-bg-opacity: 1 !important;
   background-color: rgb(245 245 245 / var(--tw-bg-opacity, 1)) !important;
@@ -2688,11 +2674,6 @@ body,
 .hover\:bg-red-500:hover{
   --tw-bg-opacity: 1;
   background-color: rgb(245 66 62 / var(--tw-bg-opacity, 1));
-}
-
-.hover\:bg-blue-100:hover{
-  --tw-bg-opacity: 1;
-  background-color: rgb(225 250 255 / var(--tw-bg-opacity, 1));
 }
 
 .hover\:\!text-gray-900:hover{
@@ -2781,6 +2762,12 @@ body,
   color: rgb(238 241 243 / var(--tw-text-opacity, 1));
 }
 
+.focus\:shadow-none:focus{
+  --tw-shadow: 0 0 #0000;
+  --tw-shadow-colored: 0 0 #0000;
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
 .focus\:outline-none:focus{
   outline: 2px solid transparent;
   outline-offset: 2px;
@@ -2836,10 +2823,6 @@ body,
 
 .disabled\:opacity-50:disabled{
   opacity: 0.5;
-}
-
-.disabled\:opacity-70:disabled{
-  opacity: 0.7;
 }
 
 .disabled\:shadow-none:disabled{

--- a/src/storybook/components/FormInputDatePicker.stories.tsx
+++ b/src/storybook/components/FormInputDatePicker.stories.tsx
@@ -1,33 +1,26 @@
-import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { Button, Space } from 'antd';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { FormProvider, useForm, useFormContext } from 'react-hook-form';
-import dayjs from 'dayjs';
-import { FormInputDatePicker, IInputProps } from '../../components/FormInputDatePicker';
-import { EDateMaskFormat } from '../../enums';
+import { FormInputDatePicker, IInputProps } from '@/components/FormInputDatePicker';
+import { EDateMaskFormat } from '@/enums';
 
-// ---------- Schema y tipos ----------
 const schema = z.object({
-	date: z.any().refine(v => !!v, { message: 'Seleccione una fecha' }),
+	date: z.string({ required_error: 'Seleccione una fecha' }).min(1, 'Seleccione una fecha'),
 });
 type FormValues = z.infer<typeof schema>;
 
-// Wrapper que obtiene el control del contexto del formulario
 const BoundFormInputDatePicker = (props: Omit<IInputProps<FormValues>, 'control'>) => {
-	const { control, watch } = useFormContext<FormValues>();
-	const date = watch('date');
-	return <FormInputDatePicker {...props} control={control as any} />;
+	const { control } = useFormContext<FormValues>();
+	return <FormInputDatePicker<FormValues> {...props} control={control} />;
 };
 
-// ---------- Wrapper con RHF ----------
 const RHFForm: React.FC<{
 	children: React.ReactNode;
 	defaultValues?: Partial<FormValues>;
 	mode?: 'onChange' | 'onBlur' | 'onSubmit' | 'onTouched' | 'all';
-	onSubmitLogLabel?: string;
-}> = ({ children, defaultValues, mode = 'onBlur', onSubmitLogLabel = 'submit' }) => {
+}> = ({ children, defaultValues, mode = 'onBlur' }) => {
 	const methods = useForm<FormValues>({
 		resolver: zodResolver(schema),
 		defaultValues: { date: undefined, ...defaultValues },
@@ -36,13 +29,7 @@ const RHFForm: React.FC<{
 
 	return (
 		<FormProvider {...methods}>
-			<form
-				onSubmit={methods.handleSubmit(data => {
-					// eslint-disable-next-line no-console
-					console.log(onSubmitLogLabel, data);
-				})}
-				style={{ width: 360 }}
-			>
+			<form onSubmit={methods.handleSubmit(() => {})} style={{ width: 360 }}>
 				<Space direction="vertical" style={{ width: '100%' }} size="middle">
 					{children}
 					<Button htmlType="submit" type="primary">
@@ -54,7 +41,6 @@ const RHFForm: React.FC<{
 	);
 };
 
-// ---------- Meta ----------
 const meta: Meta<typeof BoundFormInputDatePicker> = {
 	title: 'components/Form/FormInputDatePicker',
 	component: BoundFormInputDatePicker,
@@ -63,13 +49,13 @@ const meta: Meta<typeof BoundFormInputDatePicker> = {
 		label: { control: 'text' },
 		disabled: { control: 'boolean' },
 		placeholder: { control: 'text' },
+		minuteStep: { control: 'number' },
 	},
 };
 export default meta;
 
 type Story = StoryObj<typeof BoundFormInputDatePicker>;
 
-// ---------- Historias ----------
 export const Default: Story = {
 	name: 'Default',
 	args: {
@@ -92,7 +78,7 @@ export const WithInitialValue: Story = {
 		placeholder: 'DD-MM-YYYY',
 	},
 	render: args => (
-		<RHFForm defaultValues={{ date: dayjs('15-12-2024') }}>
+		<RHFForm defaultValues={{ date: '2024-12-15' }}>
 			<BoundFormInputDatePicker {...args} />
 		</RHFForm>
 	),
@@ -127,6 +113,22 @@ export const WithTimeAndMinutes: Story = {
 	),
 };
 
+export const WithMinuteStep: Story = {
+	name: 'Minutos cada 15 (8:00, 8:15, 8:30, 8:45)',
+	args: {
+		name: 'date',
+		label: 'Fecha y hora',
+		placeholder: 'YYYY-MM-DD HH:mm',
+		format: EDateMaskFormat.YYYYMMDD_HHMM,
+		minuteStep: 15,
+	},
+	render: args => (
+		<RHFForm defaultValues={{ date: undefined }}>
+			<BoundFormInputDatePicker {...args} />
+		</RHFForm>
+	),
+};
+
 export const ShowErrorOnSubmit: Story = {
 	name: 'Error al enviar (validación Zod)',
 	args: {
@@ -134,10 +136,8 @@ export const ShowErrorOnSubmit: Story = {
 		label: 'Seleccione una fecha',
 	},
 	render: args => (
-		<RHFForm mode="onSubmit" onSubmitLogLabel="submit-invalid">
+		<RHFForm mode="onSubmit">
 			<BoundFormInputDatePicker {...args} />
 		</RHFForm>
 	),
 };
-
-


### PR DESCRIPTION
## Descripción

Corrección de issues detectados en code review del componente **FormInputDatePicker** y adición de soporte para intervalos de minutos configurables en el panel de tiempo.

---

## Resumen de los cambios

### `src/components/FormInputDatePicker/index.tsx`

* **Removida prop muerta `showCaracteres`**: Eliminada de `IInputProps`. Era un residuo técnico de `FormInput` sin utilidad en un selector de fecha.
* **Soporte de `minuteStep`**: Implementación del prop heredado de `DatePickerProps`. Permite restringir los minutos (ej. `15` para intervalos de cuarto de hora).
* **Tipado Estricto**: Uso de `TMinuteStep = DatePickerProps['minuteStep']` para asegurar compatibilidad con las uniones de tipos de **Ant Design**.
* **Refactorización de `getShowTimeConfig`**: Inclusión de `minuteStep` como parámetro para aplicar la configuración dinámicamente en formatos con o sin segundos.

### `src/storybook/components/FormInputDatePicker.stories.tsx`

* **Tipado de `control`**: Sustitución de `as any` por el genérico correcto `FormInputDatePicker<FormValues>`, recuperando la validación del compilador sobre el prop `control`.
* **Limpieza de código muerto**:
    * Eliminación de `watch('date')` y variables asociadas que provocaban re-renders innecesarios.
    * Remoción de comentarios separadores visuales (`// ---------- X ----------`).
* **Depuración**: Eliminación de `console.log` y `eslint-disable`. Uso de callbacks vacíos delegando el monitoreo al addon **Actions** de Storybook.
* **Corrección de Data Contract**:
    * `WithInitialValue`: Cambio de objeto `dayjs` a `string` (`'2024-12-15'`), reflejando el comportamiento real del componente.
    * **Zod Schema**: Cambio de `z.any()` a `z.string().min(1, ...)` para una validación técnica precisa.
* **Mantenibilidad**: Migración de imports relativos a alias de ruta (`@/components/...`).
* **Nueva Story `WithMinuteStep`**: Documentación técnica del nuevo soporte para intervalos de tiempo.